### PR TITLE
lang: yaml: Fix TypeError undefined length

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/yaml.lua
+++ b/lua/lazyvim/plugins/extras/lang/yaml.lua
@@ -38,6 +38,8 @@ return {
                 -- Must disable built-in schemaStore support to use
                 -- schemas from SchemaStore.nvim plugin
                 enable = false,
+                -- Avoid TypeError: Cannot read properties of undefined (reading 'length')
+                url = "",
               },
             },
           },


### PR DESCRIPTION
In YAML files LSP completion is not happening because yaml-language-server is failing with error:

    TypeError: Cannot read properties of undefined (reading 'length')

from `out/server/src/languageserver/handlers/settingsHandlers.js:78:51`, which it's expecting to have `yaml.schemaStore.url.length` and it's doesn't exist.

Signed-off-by: Javier Tia <javier.tia@gmail.com>
